### PR TITLE
Add login, wall of fame, and wall of shame APIs

### DIFF
--- a/emojified_tweets_wall_of_fame/templates/emojified_tweets_wall_of_fame/authentication.html
+++ b/emojified_tweets_wall_of_fame/templates/emojified_tweets_wall_of_fame/authentication.html
@@ -12,12 +12,16 @@
     <div class="card">
       <div class="container">
         <h4>Log in to Tweetmoji</h4>
-        <form action="/action_page.php">
+        <form action="{% url 'authentication' %}" method="post">
+          {% csrf_token %}
           <label for="username">Username:</label><br>
           <input type="text" id="username" name="username"><br>
           <label for="password">Password:</label><br>
-          <input type="text" id="password" name="password"><br><br>
+          <input type="password" id="password" name="password"><br><br>
           <input type="submit" value="Log in">
+          {% if error %}
+            <p>{{ error.message }}</p>
+          {% endif %}
         </form>
       </div>
     </div>

--- a/emojified_tweets_wall_of_fame/templates/emojified_tweets_wall_of_fame/wall_of_fame.html
+++ b/emojified_tweets_wall_of_fame/templates/emojified_tweets_wall_of_fame/wall_of_fame.html
@@ -4,5 +4,8 @@
   </head>
   <body>
     <p>Base Template</p>
+    {% for tweet in tweets %}
+      <p>{{ tweet }}</p>
+    {% endfor %}
   </body>
 </html>

--- a/emojified_tweets_wall_of_fame/templates/emojified_tweets_wall_of_fame/wall_of_shame.html
+++ b/emojified_tweets_wall_of_fame/templates/emojified_tweets_wall_of_fame/wall_of_shame.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <title>Website</title>
+  </head>
+  <body>
+    <p>Base Template</p>
+    {% for tweet in tweets %}
+      <p>{{ tweet }}</p>
+    {% endfor %}
+  </body>
+</html>

--- a/emojified_tweets_wall_of_fame/urls.py
+++ b/emojified_tweets_wall_of_fame/urls.py
@@ -3,7 +3,8 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("", views.main, name="main"),
+    path("wall-of-fame", views.wall_of_fame, name="wall_of_fame"),
+    path("wall-of-shame", views.wall_of_shame, name="wall_of_shame"),
     path("health", views.health, name="health"),
     path("authentication", views.authentication, name="authentication"),
 ]

--- a/emojified_tweets_wall_of_fame/views.py
+++ b/emojified_tweets_wall_of_fame/views.py
@@ -1,10 +1,47 @@
-from django.shortcuts import render
-from django.http import HttpResponse
+from django.shortcuts import render, redirect, get_list_or_404
+from django.http import HttpResponse, HttpResponseBadRequest
+from django.contrib.auth import authenticate, login
+from .models import Tweet
+
 import json
 
 
-def main(response):
-    return render(response, "emojified_tweets_wall_of_fame/main.html", {})
+def wall_of_fame(request):
+    tweets_list = Tweet.objects.all().order_by("-votes")
+
+    tweets = []
+    for tweet in tweets_list:
+        tweet_dict = {
+            "content": tweet.content,
+            "votes": tweet.votes,
+            "poster_id": tweet.poster,
+        }
+        if len(tweets) >= 10:
+            break
+        tweets.append(tweet_dict)
+
+    return render(
+        request, "emojified_tweets_wall_of_fame/wall_of_fame.html", {"tweets": tweets}
+    )
+
+
+def wall_of_shame(request):
+    tweets_list = Tweet.objects.all().order_by("votes")
+
+    tweets = []
+    for tweet in tweets_list:
+        tweet_dict = {
+            "content": tweet.content,
+            "votes": tweet.votes,
+            "poster_id": tweet.poster,
+        }
+        if len(tweets) >= 10:
+            break
+        tweets.append(tweet_dict)
+
+    return render(
+        request, "emojified_tweets_wall_of_fame/wall_of_shame.html", {"tweets": tweets}
+    )
 
 
 def health(response):
@@ -12,5 +49,34 @@ def health(response):
     return HttpResponse(json.dumps(success_message))
 
 
-def authentication(response):
-    return render(response, "emojified_tweets_wall_of_fame/login.html", {})
+def authentication(request):
+    error = {"error": True, "fields": [], "message": "Invalid username or password."}
+
+    if request.method == "POST":
+        username = request.POST["username"]
+        password = request.POST["password"]
+        user = authenticate(request, username=username, password=password)
+        if user is not None:
+            login(request, user)
+            return redirect("wall_of_fame")
+        else:
+            if username == "" and password == "":
+                error["message"] = "Username and password cannot be empty."
+                error["fields"].append("username")
+                error["fields"].append("password")
+
+            elif username == "":
+                error["message"] = "Username cannot be empty."
+                error["fields"].append("username")
+
+            elif password == "":
+                error["message"] = "Password cannot be empty."
+                error["fields"].append("password")
+
+            return render(
+                request,
+                "emojified_tweets_wall_of_fame/authentication.html",
+                {"error": error},
+            )
+
+    return render(request, "emojified_tweets_wall_of_fame/authentication.html")

--- a/static/card.css
+++ b/static/card.css
@@ -9,7 +9,6 @@
   background: #c0deed;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
   border-radius: 12px;
-  transition: 0.3s;
 }
 
 .card:hover {
@@ -32,20 +31,21 @@
   border-radius: 12px;
 }
 
-input[type=text], select {
+input[type="text"],
+select {
   width: 100%;
   padding: 12px 20px;
   margin: 8px 0;
   display: inline-block;
-  background: #C0DEED;
+  background: #c0deed;
   border: 1px solid #ccc;
   border-radius: 12px;
   box-sizing: border-box;
 }
 
-input[type=submit] {
+input[type="submit"] {
   width: 100%;
-  background-color: #4CAF50;
+  background-color: #4caf50;
   color: white;
   padding: 14px 20px;
   margin: 8px 0;
@@ -54,6 +54,6 @@ input[type=submit] {
   cursor: pointer;
 }
 
-input[type=submit]:hover {
+input[type="submit"]:hover {
   background-color: #45a049;
 }

--- a/wall_of_fame/settings.py
+++ b/wall_of_fame/settings.py
@@ -46,6 +46,9 @@ INSTALLED_APPS = [
     "emojified_tweets_wall_of_fame.apps.EmojifiedTweetsWallOfFameConfig",
 ]
 
+# SESSION_COOKIE_SECURE = True
+# SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",


### PR DESCRIPTION
### PR Summary
Reminder this is a PR that's being pushed to a feature branch `added-styling`.

This PR adds 3 APIs in `views.py`:
1. ### `authentication`: 

- when making a POST request, make sure to send form parameters `username` and `password`
- this API will log you in if you entered valid credentials or give you an error message if not
- if logged in, you will be redirected to the `wall-of-fame`

![image](https://user-images.githubusercontent.com/46268420/103983206-da813100-5152-11eb-84fe-5f493827f84a.png)

2. ### `wall-of-fame`:
- this API opens template file `wall-of-fame.html` which for now, displays the top ten tweets sorted by votes
- the tweet looks like:
```py
{
  "content": tweet.content,
  "votes": tweet.votes,
  "poster_id": tweet.poster,
}
```

![image](https://user-images.githubusercontent.com/46268420/103983030-968e2c00-5152-11eb-8863-cd860790d0af.png)

TODO: filter out tweets with negative votes

3. ### `wall-of-shame`:
- same thing as the `wall-of-fame` but shows you the lowest 10 tweets sorted by votes

![image](https://user-images.githubusercontent.com/46268420/103983053-a3ab1b00-5152-11eb-83cf-d5180f1cc085.png)
