### PR TITLE
Fix for issue where creating a new user with a taken username causes IntegrityError

### DIFF
--- a/emojified_tweets_wall_of_fame/views.py
+++ b/emojified_tweets_wall_of_fame/views.py
@@ -106,6 +106,16 @@ def signup(request):
                 request, "emojified_tweets_wall_of_fame/signup.html", {"error": error}
             )
 
+        # check if user already exists
+        matching_username = CustomUser.objects.get(username=username)
+        if matching_username is not None:
+            error["message"] = "Username already taken."
+            error["fields"].append("username")
+
+            return render(
+                request, "emojified_tweets_wall_of_fame/signup.html", {"error": error}
+            )
+
         new_user = CustomUser.objects.create(
             username=username, password=make_password(password), email=email
         )

--- a/emojified_tweets_wall_of_fame/views.py
+++ b/emojified_tweets_wall_of_fame/views.py
@@ -107,7 +107,11 @@ def signup(request):
             )
 
         # check if user already exists
-        matching_username = CustomUser.objects.get(username=username)
+        try:
+            matching_username = CustomUser.objects.get(username=username)
+        except CustomUser.DoesNotExist:
+            matching_username = None
+
         if matching_username is not None:
             error["message"] = "Username already taken."
             error["fields"].append("username")


### PR DESCRIPTION
### PR Summary
Fix for https://github.com/mhyeun/emojified-tweets-wall-of-fame/issues/10.

This PR adds a handler in the signup view to handle the case where a user might try to sign up with a taken username. In this case, you will be redirected to the signup view with an error showing "Username already taken".